### PR TITLE
Kubernetes controllers

### DIFF
--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: frontend
+        image: polovina/frontend:v0.0.2
+        ports:   
+        - containerPort: 8080
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 8080
+            httpHeaders:
+            - name: "Cookie"
+              value: "shop_session-id=x-readiness-probe"
+        livenessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 8080
+            httpHeaders:
+            - name: "Cookie"
+              value: "shop_session-id=x-liveness-probe"
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: polovina/frontend:v0.0.2
+        ports:
+        - containerPort: 8080
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"

--- a/kubernetes-controllers/node-exporter-daemonset.yaml
+++ b/kubernetes-controllers/node-exporter-daemonset.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  namespace: kube-system
+  labels:
+    app: node-exporter
+spec:
+  selector:
+    matchLabels:
+      name: node-exporter
+  template:
+    metadata:
+      labels:
+        name: node-exporter
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: node-exporter
+        image: quay.io/prometheus/node-exporter:latest
+        ports:
+        - containerPort: 9100
+          protocol: TCP
+        securityContext:
+          privileged: true
+        args:
+          - --path.rootfs=/host
+        volumeMounts:
+          - name: rootfs
+            mountPath: /host
+      volumes:
+        - name: rootfs
+          emptyDir: {}

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0%
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: polovina/paymentservice:v0.0.2

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: polovina/paymentservice:v0.0.2

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: polovina/paymentservice:v0.0.1

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: polovina/paymentservice:v0.0.1

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -7,27 +7,11 @@ metadata:
   name: frontend
 spec:
   containers:
-  - image: polovina/hw1:frontend
+  - image: polovina/frontend
     name: frontend
     resources: {}
     ports:
     - containerPort: 8080
-    readinessProbe:
-      initialDelaySeconds: 10
-      httpGet:
-        path: "/_healthz"
-        port: 8080
-        httpHeaders:
-        - name: "Cookie"
-          value: "shop_session-id=x-readiness-probe"
-    livenessProbe:
-      initialDelaySeconds: 10
-      httpGet:
-        path: "/_healthz"
-        port: 8080
-        httpHeaders:
-        - name: "Cookie"
-          value: "shop_session-id=x-liveness-probe"
     env:
     - name: PORT
       value: "8080"


### PR DESCRIPTION
1. при запуске пода возникает ошибка:
MacBook-Elena$ kubectl apply -f kubernetes-controllers/frontend-replicaset.yaml
error: error validating "kubernetes-controllers/frontend-replicaset.yaml": error validating data: ValidationError(ReplicaSet.spec): missing required field "selector" in io.k8s.api.apps.v1.ReplicaSetSpec; if you choose to ignore these errors, turn validation off with --validate=false
---->>>>не указан selector, после указания под запустился:

MacBook-Elena$ kubectl get pods -l app=frontend
NAME             READY   STATUS    RESTARTS   AGE
frontend-vp7ss   1/1     Running   0          2m6sfrontend   1         0         0       10s

2. Почему при изменении образа в файле  frontend-replicaset.yaml  и apply -f из него ничего не происходит, а версия меняется только после удаления подов?
----->>> Потому что ReplicaSet управляет количеством запущенных подов, и не умеет пересоздавать их налету  при изменении конфигурации, это умеет Deployment.  При удалении подов ReplicaSet видит что их нет, а надо 3, считывает конфиг и запускает уже поды с новой версией.

3. Создан Deployment
MacBook-Elena$ kubectl apply -f ekolibri_platform/kubernetes-controllers/paymentservice-deployment.yaml | kubectl get pods -l app=payment -w
NAME                       READY   STATUS    RESTARTS   AGE
payment-86766bc788-fvzsz   1/1     Running   0          3m59s
payment-86766bc788-tv5gr   1/1     Running   0          3m59s
payment-86766bc788-xdvsv   1/1     Running   0          3m59s
payment-7c8f7fc785-f6sss   0/1     ContainerCreating   0          0s
payment-7c8f7fc785-f6sss   1/1     Running             0          9s
payment-86766bc788-xdvsv   1/1     Terminating         0          4m19s
payment-7c8f7fc785-w65jw   0/1     ContainerCreating   0          21s
payment-86766bc788-xdvsv   0/1     Terminating         0          4m59s
payment-7c8f7fc785-w65jw   1/1     Running             0          47s
payment-86766bc788-xdvsv   0/1     Terminating         0          5m39s
payment-86766bc788-xdvsv   0/1     Terminating         0          5m39s
payment-86766bc788-tv5gr   1/1     Terminating         0          6m15s
payment-7c8f7fc785-8lfwz   0/1     ContainerCreating   0          11s
payment-86766bc788-tv5gr   0/1     Terminating         0          6m48s
payment-7c8f7fc785-8lfwz   1/1     Running             0          49s
payment-86766bc788-fvzsz   1/1     Terminating         0          7m10s

Пересозданы с новым образом:
acBook-Elena$ kubectl get pods -l app=payment -o jsonpath="{.items[0:3].spec.containers[0].image}"
polovina/paymentservice:v0.0.2 polovina/paymentservice:v0.0.2 polovina/paymentservice:v0.0.2

Присутствуют две RS
MacBook-Elena$ kubectl get rs
NAME                 DESIRED   CURRENT   READY   AGE
payment-7c8f7fc785   3         3         3       9m37s
payment-86766bc788   0         0         0       13m

Откат прошел до первой версии:
MacBook-Elena:$ kubectl rollout undo deployment payment --to-revision=1
MacBook-Elena$ kubectl get pods -l app=payment -o jsonpath="{.items[0:3].spec.containers[0].image}"
polovina/paymentservice:v0.0.1 polovina/paymentservice:v0.0.1 polovina/paymentservice:v0.0.1

4. Создан деплоймент paymentservice-deployment-bg.yaml
Здесь при выставлении maxSurge: 100% поднимаются три ноды с новой версией, однако старые не терминируются. Поэтому необходимо  поставить деплой на паузу, и сделать, например, scale:
MacBook-Elena$ kubectl rollout pause deployment paymentservice
deployment.apps/paymentservice paused
MacBook-Elena$ kubectl scale deployment.apps/paymentservice --replicas=3
deployment.apps/paymentservice scaled
MacBook-Elena$ kubectl get pods -l app=paymentservice
NAME                             READY   STATUS    RESTARTS   AGE
paymentservice-8799cb596-h6lll   1/1     Running   0          3m1s
paymentservice-8799cb596-rvtf6   1/1     Running   0          3m1s
paymentservice-8799cb596-sdkzj   1/1     Running   0          3m1s
MacBook-Elena$ kubectl get pods -l app=paymentservice -o=jsonpath="{.items[0:3].spec.containers[0].image}"
polovina/paymentservice:v0.0.2 polovina/paymentservice:v0.0.2 polovina/paymentservice:v0.0.2

Еще как вариант, можно после постановки на паузу изменить конфиг деплоя, например убрать maxSurge и maxUnavailable тогда не отвечающие версии образа ноды тоже затерминируются.

5. Создан деплоймент paymentservice-deployment-reversr.yaml

6. Создан деплоймент frontend c livenesProbe, при изменении на /_health ошибка:
Events:
  Type     Reason     Age               From               Message
  ----     ------     ----              ----               -------
  Normal   Started    30s               kubelet            Started container frontend
  Warning  Unhealthy  9s (x2 over 19s)  kubelet            Liveness probe failed: HTTP probe failed with statuscode: 404
  Warning  Unhealthy  6s (x2 over 16s)  kubelet            Readiness probe failed: HTTP probe failed with statuscode: 404

7. В node-exporter для запуска на мастер нодах необходимо добавить
      tolerations:
      - key: node-role.kubernetes.io/master
        effect: NoSchedule
