### PR TITLE
kube-volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,39 @@
 # ekolibri_platform
 ekolibri Platform repository
+
+Задание №4 VOLUMES
+
+1. Создан secret verysecret, куда помещены значения переменных в base64
+2. Запущен statefulset
+
+MacBook-Elena:~ elenakolibri$ kubectl describe statefulset minio
+Name:               minio
+Namespace:          default
+CreationTimestamp:  Fri, 23 Apr 2021 23:56:18 +0300
+Selector:           app=minio
+Labels:             <none>
+Annotations:        <none>
+Replicas:           1 desired | 1 total
+Update Strategy:    RollingUpdate
+  Partition:        0
+Pods Status:        0 Running / 1 Waiting / 0 Succeeded / 0 Failed
+Pod Template:
+  Labels:  app=minio
+  Containers:
+   minio:
+    Image:      minio/minio:RELEASE.2019-07-10T00-34-56Z
+    Port:       9000/TCP
+    Host Port:  0/TCP
+    Args:
+      server
+      /data
+    Liveness:  http-get http://:9000/minio/health/live delay=120s timeout=1s period=20s #success=1 #failure=3
+    Environment Variables from:
+      verysecret  Secret  Optional: false
+    Environment:  <none>
+
+------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------
 Задание №2
 1. при запуске пода возникает ошибка:
 MacBook-Elena:ekolibri_platform elenakolibri$ kubectl apply -f kubernetes-controllers/frontend-replicaset.yaml 

--- a/kubernetes-volumes/minio-headless-service.yaml
+++ b/kubernetes-volumes/minio-headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        envFrom:
+          - secretRef: 
+              name: verysecret
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above. 
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi

--- a/kubernetes-volumes/secret.yaml
+++ b/kubernetes-volumes/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: verysecret
+type: Opaque
+data:
+  MINIO_ACCESS_KEY: bWluaW8=
+  MINIO_SECRET_KEY: bWluaW8xMjM=


### PR DESCRIPTION
1. Создан secret verysecret, куда помещены значения переменных в base64
apiVersion: v1
kind: Secret
metadata:
  name: verysecret
type: Opaque
data:
  MINIO_ACCESS_KEY: bWluaW8=
  MINIO_SECRET_KEY: bWluaW8xMjM=
2. Изменен и запущен statefulset
_____________________________________________
    spec:
       containers:
       - name: minio
          envFrom:
            - secretRef:
              name: verysecret

____________________________________________
MacBook-Elena:~ elenakolibri$ kubectl describe statefulset minio
Name:               minio
Namespace:          default
CreationTimestamp:  Fri, 23 Apr 2021 23:56:18 +0300
Selector:           app=minio
Labels:             <none>
Annotations:        <none>
Replicas:           1 desired | 1 total
Update Strategy:    RollingUpdate
  Partition:        0
Pods Status:        0 Running / 1 Waiting / 0 Succeeded / 0 Failed
Pod Template:
  Labels:  app=minio
  Containers:
   minio:
    Image:      minio/minio:RELEASE.2019-07-10T00-34-56Z
    Port:       9000/TCP
    Host Port:  0/TCP
    Args:
      server
      /data
    Liveness:  http-get http://:9000/minio/health/live delay=120s timeout=1s period=20s #success=1 #failure=3
    Environment Variables from:
      verysecret  Secret  Optional: false
    Environment:  <none>
