### PR TITLE
kube-networks

### DIFF
--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -14,6 +14,10 @@ spec:
         mountPath: "/app"
       ports:
         - containerPort: 8000
+      readinessProbe:
+        httpGet:
+          path: /index.html 
+          port: 8000
   initContainers:
     - name: init-web
       image: busybox:latest

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -18,6 +18,8 @@ spec:
         httpGet:
           path: /index.html 
           port: 8000
+      livenessProbe:
+        tcpSocket: { port: 8000 }
   initContainers:
     - name: init-web
       image: busybox:latest

--- a/kubernetes-networks/canary/web_v1.yaml
+++ b/kubernetes-networks/canary/web_v1.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-app-v1
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+      version: v1
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+        version: v1
+    spec:
+      containers:
+        - name: web
+          image: polovina/hw1:v1
+          volumeMounts:
+          - name: app
+            mountPath: "/app"
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /index.html 
+              port: 8000
+      initContainers:
+        - name: init-web
+          image: busybox:latest
+          command: ['sh', '-c', 'wget -O-  https://tinyurl.com/otus-k8s-intro | sh']
+          volumeMounts:
+          - name: app
+            mountPath: "/app"
+      volumes:
+        - name: app
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-v1 
+spec:
+  selector:
+    app: web
+    version: v1
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - protocol: TCP 
+    port: 80
+    targetPort: 8000
+

--- a/kubernetes-networks/canary/web_v1_ingress.yaml
+++ b/kubernetes-networks/canary/web_v1_ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web-v1
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - host: canary.example.com
+    http:
+      paths:
+      - path: /web
+        pathType: Prefix
+        backend:
+          service:
+            name: web-svc-v1
+            port:
+              number: 8000

--- a/kubernetes-networks/canary/web_v2.yaml
+++ b/kubernetes-networks/canary/web_v2.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-app-v2
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+      version: v2
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+        version: v2
+    spec:
+      containers:
+        - name: web
+          image: polovina/hw1:v2
+          volumeMounts:
+          - name: app
+            mountPath: "/app"
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /index.html 
+              port: 8000
+      initContainers:
+        - name: init-web
+          image: busybox:latest
+          command: ['sh', '-c', 'wget -O-  https://tinyurl.com/otus-k8s-intro | sh']
+          volumeMounts:
+          - name: app
+            mountPath: "/app"
+      volumes:
+        - name: app
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-v2 
+spec:
+  selector:
+    app: web
+    version: v2
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - protocol: TCP 
+    port: 80
+    targetPort: 8000
+

--- a/kubernetes-networks/canary/web_v2_ingress.yaml
+++ b/kubernetes-networks/canary/web_v2_ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web-v2
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-by-header: "canary"
+    nginx.ingress.kubernetes.io/canary-by-header-value: "true"
+spec:
+  rules:
+  - host: canary.example.com
+    http:
+      paths:
+      - path: /web
+        pathType: Prefix
+        backend:
+          service:
+            name: web-svc-v2
+            port:
+              number: 8000

--- a/kubernetes-networks/coredns/core-svc-lb.yaml
+++ b/kubernetes-networks/coredns/core-svc-lb.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-tcp-ext 
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: kube-dns
+spec:
+  selector:
+    app.kubernetes.io/name: kube-dns
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.10
+  ports:
+  - protocol: TCP
+    port: 53
+    targetPort: 53
+  selector:
+    k8s-app: kube-dns
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-udp-ext   
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: kube-dns
+spec:
+  selector:
+    app.kubernetes.io/name: kube-dns
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.10
+  ports:
+  - protocol: UDP
+    port: 53
+    targetPort: 53
+  selector:
+    k8s-app: kube-dns

--- a/kubernetes-networks/dashboard/dash-ingress.yaml
+++ b/kubernetes-networks/dashboard/dash-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dashboard
+  namespace: kubernetes-dashboard
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^(/dashboard)$ $1/ redirect;
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /dashboard(/|$)(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: kubernetes-dashboard
+            port:
+              number: 443
+

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: | 
+    address-pools:
+      - name: default 
+        protocol: layer2 
+        addresses:
+          - "172.17.255.1-172.17.255.255"
+

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,18 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx 
+  namespace: ingress-nginx 
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx 
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx 
+    app.kubernetes.io/instance: ingress-nginx 
+    app.kubernetes.io/component: controller
+  ports:
+    - { name: http, port: 80, targetPort: http }
+    - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -31,6 +31,8 @@ spec:
             httpGet:
               path: /index.html 
               port: 8000
+          livenessProbe:
+            tcpSocket: { port: 8000 }
       initContainers:
         - name: init-web
           image: busybox:latest

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
+      maxSurge: 100%
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: polovina/hw1:latest
+          imagePullPolicy: Always
+          volumeMounts:
+          - name: app
+            mountPath: "/app"
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /index.html 
+              port: 8000
+      initContainers:
+        - name: init-web
+          image: busybox:latest
+          command: ['sh', '-c', 'wget -O-  https://tinyurl.com/otus-k8s-intro | sh']
+          volumeMounts:
+          - name: app
+            mountPath: "/app"
+      volumes:
+        - name: app
+          emptyDir: {}
+

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1 
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: / 
+spec:
+  rules: 
+  - http:
+      paths:
+      - path: /web
+        pathType: Prefix
+        backend:
+          service:
+            name: web-svc 
+            port: 
+              number: 8000

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1 
+apiVersion: networking.k8s.io/v1beta1 
 kind: Ingress
 metadata:
   name: web
@@ -9,9 +9,6 @@ spec:
   - http:
       paths:
       - path: /web
-        pathType: Prefix
         backend:
-          service:
-            name: web-svc 
-            port: 
-              number: 8000
+          serviceName: web-svc
+          servicePort: 8000 

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip 
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+  - protocol: TCP 
+    port: 80
+    targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -8,6 +8,6 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-  - protocol: TCP 
-    port: 80
-    targetPort: 8000
+    - protocol: TCP 
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc 
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - protocol: TCP 
+    port: 80
+    targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb 
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+  - protocol: TCP 
+    port: 80
+    targetPort: 8000


### PR DESCRIPTION

1.Создан деплоймент и сервис для web-pod.
. Почему следующая конфигурация валидна, но не имеет смысла?
livenessProbe:
  exec:
command:
- 'sh'
- '-c'
- 'ps aux | grep my_web_server_process'
Потому что эта проверка смотрит запущен ли внутри контейнера процесс, но не показывает доступен ли сервис извне.
. Бывают ли ситуации, когда она все-таки имеет смысл?
Думаю, это может понадобится если мы хотим перезапускать контейнер при остановке определенного процесса, который не торчит вовне, правда, если он по-каким-то причинам скрашился в одном контейнере, то вероятно скрашится и в других, а это может привести к цикличной перезагрузке контейнеров. Я бы лучше использовала Restart=on-failure для процесса в systemd, и мониоринг процесса какими-нибудь средствами.
2. Deployment:
maxSurge и maxUnavailable не могут быть вместе 0, это указано в документации
https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
The absolute number is calculated from percentage by rounding down. The value cannot be 0 if .spec.strategy.rollingUpdate.maxSurge is 0.
RollingUpdate не сможет ни создать Pod ни убить.

3.MetalLB | Проверка конфигурации
{"caller":"service.go:114","event":"ipAllocated","ip":"172.17.255.2","msg":"IP address assigned by controller","service":"default/web-svc-lb","ts":"2021-05-03T09:20:28.393469257Z"}

4. DNS через MetalLB
Созданы манифесты

Name:                     coredns-tcp-ext
Namespace:                kube-system
Labels:                   <none>
Annotations:              metallb.universe.tf/allow-shared-ip: kube-dns
Selector:                 k8s-app=kube-dns
Type:                     LoadBalancer
IP Families:              <none>
IP:                       10.98.138.59
IPs:                      10.98.138.59
IP:                       172.17.255.10
LoadBalancer Ingress:     172.17.255.10
Port:                     <unset>  53/TCP
TargetPort:               53/TCP
NodePort:                 <unset>  32322/TCP
Endpoints:                172.17.0.2:53
Session Affinity:         None
External Traffic Policy:  Cluster
Events:                   <none>


Name:                     coredns-udp-ext
Namespace:                kube-system
Labels:                   <none>
Annotations:              metallb.universe.tf/allow-shared-ip: kube-dns
Selector:                 k8s-app=kube-dns
Type:                     LoadBalancer
IP Families:              <none>
IP:                       10.101.218.236
IPs:                      10.101.218.236
IP:                       172.17.255.10
LoadBalancer Ingress:     172.17.255.10
Port:                     <unset>  53/UDP
TargetPort:               53/UDP
NodePort:                 <unset>  32378/UDP
Endpoints:                172.17.0.2:53
Session Affinity:         None
External Traffic Policy:  Cluster
Events:                   <none>

MacBook-Elena:~ elenakolibri$ nslookup web-svc-lb.default.svc.cluster.local 172.17.255.10
Server:         172.17.255.10
Address:        172.17.255.10#53

Name:   web-svc-lb.default.svc.cluster.local
Address: 10.98.110.131

MacBook-Elena:~ elenakolibri$ nslookup kubernetes.default.svc.cluster.local 172.17.255.10
Server:         172.17.255.10
Address:        172.17.255.10#53

Name:   kubernetes.default.svc.cluster.local
Address: 10.96.0.1

5. Создан ingress для dashboard
6. Создан canary на основе заголовка "canary: true"

MacBook-Elena:~$ cat /etc/hosts | grep canary.example.com
172.17.255.3 canary.example.com

MacBook-Elena:~$ curl -H "canary: true" http://canary.example.com/web | grep HOSTNAME
export HOSTNAME='web-app-v2-7fdf5c7c67-khrl7'
MacBook-Elena:~$ curl -H "canary: fsdfsdf" http://canary.example.com/web | grep HOSTNAME
export HOSTNAME='web-app-v1-64d7c7bc5f-vh8nx'
MacBook-Elena:~$ curl -H "canary: always" http://canary.example.com/web | grep HOSTNAME
export HOSTNAME='web-app-v1-64d7c7bc5f-wd9xr'
MacBook-Elena:~$ curl  http://canary.example.com/web | grep HOSTNAME
export HOSTNAME='web-app-v1-64d7c7bc5f-dhsvx'

